### PR TITLE
Add Airspy HF+ support

### DIFF
--- a/Makefile.airspyhf
+++ b/Makefile.airspyhf
@@ -1,0 +1,18 @@
+
+CFLAGS= -Ofast -pthread -D WITH_AIRSPYHF -I.  `pkg-config --cflags libairspyhf`
+LIBS= -Ofast -lm -pthread  `pkg-config --libs libairspyhf` -lusb-1.0 
+
+CC=gcc
+
+all: vortrack
+
+vortrack: airspyhf.o vor.o vortrack.o
+	$(CC) -o vortrack airspyhf.o vor.o vortrack.o $(LIBS) $(LDFLAGS)
+
+test:	vor.o test.o
+	$(CC) -o test vor.o test.o $(LIBS) $(LDFLAGS)
+
+vortrack.o: vortrack.c vortrack.h
+
+clean:
+	rm -f *.o vortrack

--- a/Makefile.rtl
+++ b/Makefile.rtl
@@ -1,5 +1,5 @@
 CFLAGS=-Ofast -W -D WITH_RTL  -I /usr/local/include/librtlsdr
-LIBS=  -lusb-1.0 -lpthread -L /usr/local/lib -lrtlsdr -lm -lrt 
+LIBS= -lusb-1.0 -lrtlsdr -lpthread -L/usr/local/lib -lm
 
 
 all: vortrack

--- a/README.md
+++ b/README.md
@@ -20,11 +20,15 @@ git the radial in degree from the VOR.
 
 ## Build
 
-airwav depends of usb lib and rtlsdr or airspy lib
+vortrack depends of usb lib and rtlsdr/airspy/airspyhf lib
 
 For rtl sdr :
 > make -f Makefile.rtl
 
 for airspy :
 > make -f Makefile.airspy
+
+for Airspy HF :
+> make -f Makefile.airspyhf
+
 

--- a/airspyhf.c
+++ b/airspyhf.c
@@ -45,10 +45,10 @@ static int rx_callback(airspyhf_transfer_t * transfer)
 	float *p = (float *)(transfer->samples);
 
 	for (i = 0; i < transfer->sample_count; i++) {
-	        float re, im;
+		float re, im;
 
 		re = p[i * 2];
-	        im = p[(i * 2) + 1];
+		im = p[(i * 2) + 1];
 
 		// Fs/4 downsampler
 		switch(idx_ds) {
@@ -69,25 +69,25 @@ static int rx_callback(airspyhf_transfer_t * transfer)
 			    idx_ds = 0;
 			    break;
 			default:
-      			// unreachable, error here;
-      			    assert(idx_ds < 4);
-      			    break;
+			// unreachable, error here;
+			    assert(idx_ds < 4);
+			    break;
     		}	
 
 		// linear interpolation
 		for (j = 0; j < CYCLE_INPUT; j++) {
-			Values[idx_input + j] = 
+			Values[idx_input + j] =
 				D + ((D - D_old) * j / CYCLE_INPUT);
 		}
 		idx_input += CYCLE_INPUT;
 		D_old = D;
 
-                if (idx_input == CYCLE_IO) {
+		if (idx_input == CYCLE_IO) {
 			for (k = 0; k < CYCLE_INPUT; k++) {
-		          vor(cabs(Values[k * CYCLE_OUTPUT]) / (float)DOWNSC);
+			  vor(cabs(Values[k * CYCLE_OUTPUT]) / (float)DOWNSC);
 			}
-                        idx_input = 0;
-                }
+			idx_input = 0;
+		}
 
 	}
 

--- a/airspyhf.c
+++ b/airspyhf.c
@@ -31,7 +31,6 @@ static struct airspyhf_device *device = NULL;
 #define CYCLE_OUTPUT (384)
 #define CYCLE_IO (CYCLE_INPUT * CYCLE_OUTPUT)
 
-static complex float Osc[CYCLE_IO];
 static complex float V = 0;
 static complex float D = 0;
 static complex float D_old = 0;
@@ -76,15 +75,18 @@ static int rx_callback(airspyhf_transfer_t * transfer)
 
 		// linear interpolation
 		for (j = 0; j < CYCLE_INPUT; j++) {
-			Values[idx_input + j] =
+			complex float val =
 				D + ((D - D_old) * j / CYCLE_INPUT);
+			Values[idx_input + j] = val;
 		}
 		idx_input += CYCLE_INPUT;
 		D_old = D;
 
 		if (idx_input == CYCLE_IO) {
 			for (k = 0; k < CYCLE_INPUT; k++) {
-			  vor(cabs(Values[k * CYCLE_OUTPUT]) / (float)DOWNSC);
+			  double input_val;
+			  input_val = cabs(Values[k * CYCLE_OUTPUT]);
+			  vor(input_val / (float)DOWNSC);
 			}
 			idx_input = 0;
 		}

--- a/airspyhf.c
+++ b/airspyhf.c
@@ -1,0 +1,160 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <math.h>
+#include <complex.h>
+#include <libairspyhf/airspyhf.h>
+#include <assert.h>
+#include "vortrack.h"
+
+#define INRATE 768000
+#define IFFREQ 50000
+// FSINT is 50000
+#define DOWNSC (INRATE/FSINT)
+
+extern int verbose;
+extern int gain;
+
+#ifndef bool
+typedef int bool;
+#define true 1
+#define false 0
+#endif
+
+extern void vor(float V);
+
+static struct airspyhf_device *device = NULL;
+
+// fractional downsampling of 50/768 = 25/384 is required
+// 384*25 = 9600
+#define CYCLE_INPUT (25)
+#define CYCLE_OUTPUT (384)
+#define CYCLE_IO (CYCLE_INPUT * CYCLE_OUTPUT)
+
+static complex float Osc[CYCLE_IO];
+static complex float V = 0;
+static complex float D = 0;
+static complex float D_old = 0;
+static complex float Values[CYCLE_IO];
+static int idx_input = 0;
+static int idx_ds = 0;
+
+static int rx_callback(airspyhf_transfer_t * transfer)
+{
+	int i, j, k;
+	float *p = (float *)(transfer->samples);
+
+	for (i = 0; i < transfer->sample_count; i++) {
+	        float re, im;
+
+		re = p[i * 2];
+	        im = p[(i * 2) + 1];
+
+		// Fs/4 downsampler
+		switch(idx_ds) {
+			case 0:
+			    D = CMPLXF(re, im);
+			    idx_ds = 1;
+			    break;
+			case 1:
+			    D = CMPLXF(im, -re);
+			    idx_ds = 2;
+			    break;
+			case 2:
+			    D = CMPLXF(-re, -im);
+			    idx_ds = 3;
+			    break;
+			case 3:
+			    D = CMPLXF(-im, re);
+			    idx_ds = 0;
+			    break;
+			default:
+      			// unreachable, error here;
+      			    assert(idx_ds < 4);
+      			    break;
+    		}	
+
+		// linear interpolation
+		for (j = 0; j < CYCLE_INPUT; j++) {
+			Values[idx_input + j] = 
+				D + ((D - D_old) * j / CYCLE_INPUT);
+		}
+		idx_input += CYCLE_INPUT;
+		D_old = D;
+
+                if (idx_input == CYCLE_IO) {
+			for (k = 0; k < CYCLE_INPUT; k++) {
+		          vor(cabs(Values[k * CYCLE_OUTPUT]) / (float)DOWNSC);
+			}
+                        idx_input = 0;
+                }
+
+	}
+
+	return 0;
+}
+
+int init_airspyhf(int freq)
+{
+	int result;
+	uint32_t i, count;
+	uint32_t *supported_samplerates;
+	int Fc;
+
+	result = airspyhf_open(&device);
+	if (result != AIRSPYHF_SUCCESS) {
+		fprintf(stderr, "airspyhf_open() failed (%d)\n",
+			result);
+		return -1;
+	}
+
+	airspyhf_get_samplerates(device, &count, 0);
+	supported_samplerates = (uint32_t *) malloc(count * sizeof(uint32_t));
+	airspyhf_get_samplerates(device, supported_samplerates, count);
+	for (i = 0; i < count; i++)
+		if (supported_samplerates[i] == INRATE)
+			break;
+	if (i >= count) {
+		fprintf(stderr, "did not find required sampling rate\n");
+		airspyhf_close(device);
+		return -1;
+	}
+	free(supported_samplerates);
+
+	result = airspyhf_set_samplerate(device, i);
+	if (result != AIRSPYHF_SUCCESS) {
+		fprintf(stderr, "airspyhf_set_samplerate() failed (%d)\n",
+			result);
+		airspyhf_close(device);
+		return -1;
+	}
+
+	Fc = freq + IFFREQ - INRATE/4;
+	result = airspyhf_set_freq(device, Fc);
+	if (result != AIRSPYHF_SUCCESS) {
+		fprintf(stderr, "airspyhf_set_freq() failed (%d)\n",
+			result);
+		airspyhf_close(device);
+		return -1;
+	}
+
+	return 0;
+}
+
+int runAirspyHF(void)
+{
+	int result;
+
+	result = airspyhf_start(device, rx_callback, NULL);
+	if (result != AIRSPYHF_SUCCESS) {
+		fprintf(stderr, "airspyhf_start() failed (%d)\n",
+			result);
+		return -1;
+	}
+
+	do {
+		sleep(1);
+	} while (airspyhf_is_streaming(device) == true);
+
+	return 0;
+}

--- a/vortrack.c
+++ b/vortrack.c
@@ -30,6 +30,10 @@ int init_airspy(int freq);
 int runAirspy(void);
 int gain = 18;
 #endif
+#ifdef WITH_AIRSPYHF
+int init_airspyhf(int freq);
+int runAirspyHF(void);
+#endif
 
 
 static void sighandler(int signum);
@@ -38,7 +42,10 @@ static void usage(void)
 {
 	fprintf(stderr,
 		"vor receiver Copyright (c) 2018 Thierry Leconte \n\n");
-#if WITH_AIRSPY
+#ifdef WITH_AIRSPYHF
+	fprintf(stderr, "Usage: vortrack [-l interval ] frequency in MHz\n");
+#endif
+#ifdef WITH_AIRSPY
 	fprintf(stderr, "Usage: vortrack [-g gain] [-l interval ] frequency in MHz\n");
 	fprintf(stderr, " -g gain :\t\t\tlinearity gain [0-21] default 18\n");
 #endif
@@ -65,9 +72,11 @@ int main(int argc, char **argv)
 		case 'l':
 			interval = atoi(optarg);
 			break;
+#ifdef WITH_AIRSPY
 		case 'g':
 			gain = atoi(optarg);
 			break;
+#endif
 #ifdef WITH_RTL
 		case 'p':
 			ppm = atoi(optarg);
@@ -110,6 +119,12 @@ int main(int argc, char **argv)
 	if (init_airspy(freq))
 		exit(-1);
 	runAirspy();
+#endif
+
+#ifdef WITH_AIRSPYHF
+	if (init_airspyhf(freq))
+		exit(-1);
+	runAirspyHF();
 #endif
 	sighandler(0);
 	exit(0);


### PR DESCRIPTION
Add Airspy HF+ support.
Require libairspyhf.
Note: the sampling rate of Airspy HF+ is 768kHz; fractional resampling by linear interpolation required in rx_callback().