### PR TITLE
remove rt from linked libs

### DIFF
--- a/Makefile.rtl
+++ b/Makefile.rtl
@@ -1,5 +1,5 @@
 CFLAGS=-Ofast -W -D WITH_RTL  -I /usr/local/include/librtlsdr
-LIBS=  -lusb-1.0 -lpthread -L /usr/local/lib -lrtlsdr -lm -lrt 
+LIBS=  -lusb-1.0 -lpthread -L /usr/local/lib -lrtlsdr -lm
 
 
 all: vortrack

--- a/rtl.c
+++ b/rtl.c
@@ -89,10 +89,17 @@ int initRtl(int dev_index, int fr)
 		return r;
 	}
 
-	rtlsdr_set_tuner_gain_mode(dev, 1);	/* no agc */
-	r = rtlsdr_set_tuner_gain(dev, nearest_gain(gain));
-	if (r < 0)
-		fprintf(stderr, "WARNING: Failed to set gain.\n");
+	if (0 == gain) {
+		fprintf(stderr, "Enabling AGC!\n");
+		rtlsdr_set_tuner_gain_mode(dev, 0);
+	} else {
+		rtlsdr_set_tuner_gain_mode(dev, 1);	/* no agc */
+		int gain_actual = nearest_gain(gain);
+		fprintf(stderr, "Setting gain %f\n", (float)gain_actual/10.0);
+		r = rtlsdr_set_tuner_gain(dev, nearest_gain(gain_actual));
+		if (r < 0)
+			fprintf(stderr, "WARNING: Failed to set gain.\n");
+	}
 
 	if (ppm != 0) {
 		r = rtlsdr_set_freq_correction(dev, ppm);


### PR DESCRIPTION
rt isn't needed past glibc 2.17 (and including it causes fatal link error on macos)